### PR TITLE
removed proceed button from pda

### DIFF
--- a/wallet-enterprise-configurations/pda1-issuer/src/configuration/locale.ts
+++ b/wallet-enterprise-configurations/pda1-issuer/src/configuration/locale.ts
@@ -21,7 +21,7 @@ const locale = {
 		},
 		index: {
 			header: "PDA1 Issuer",
-			phrase: "I want to receive my Portable Document A1",
+			phrase: "Portable Document A1",
 			proceed: "Proceed",
 			heading: "PDA1 Issuer",
 			paragraph: "This is a portal where citizens can receive their digital PDA1 in their wallet. To proceed you must first have an EUDI wallet from a provider of your choice. This Verifiable PDA1 will contain the Social Security Number as your personal identifier for social security.",

--- a/wallet-enterprise-configurations/pda1-issuer/views/index.pug
+++ b/wallet-enterprise-configurations/pda1-issuer/views/index.pug
@@ -9,7 +9,7 @@ block layout-content
 					img(src="/images/pda1.png", alt="Descriptive text", class="index-card")
 					p.title #{locale.index.phrase}
 					p.text-area #{locale.index.subtitle}
-					button.Btn.Large.Landing(id="mainBtn" type="submit") #{locale.index.proceed}
+					//- button.Btn.Large.Landing(id="mainBtn" type="submit") #{locale.index.proceed}
 					input(type="hidden" id="initiate_pre_authorized" name="initiate_pre_authorized" value="true")
 			//- div.item.VerifierSection
 			//- 	.ItemLayout


### PR DESCRIPTION
 removed proceed button from pda issuer landing page to prevent errors due to the missing issuer state